### PR TITLE
Switch to more efficient alphanumeric QRCodes

### DIFF
--- a/hooks/use-payment-generation.ts
+++ b/hooks/use-payment-generation.ts
@@ -26,7 +26,7 @@ export function usePaymentGeneration() {
 
   const generateQRCode = async (invoice: string) => {
     try {
-      const qrDataUrl = await QRCode.toDataURL(invoice, {
+      const qrDataUrl = await QRCode.toDataURL(invoice.toUpperCase(), {
         width: 300,
         margin: 2,
         color: {


### PR DESCRIPTION
Until now the generated QRCodes used the binary character set. By making the invoice upper case, QRCode.toDataURL automatically uses the alphanumeric character set instead of the binary one. This reduces the size of the generated QRCodes.

Before:
![image](https://github.com/user-attachments/assets/3622b772-68a4-4f5a-8319-bba3d88be301)

After:
![image](https://github.com/user-attachments/assets/4d7a2d25-eff4-4248-83c5-f73f69a4bb42)